### PR TITLE
Changing the Github CI workflow triggers

### DIFF
--- a/.github/workflows/backend_code_quality.yaml
+++ b/.github/workflows/backend_code_quality.yaml
@@ -1,6 +1,10 @@
 name: Code Quality Check Flow
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   code-quality-check:

--- a/.github/workflows/backend_testing.yaml
+++ b/.github/workflows/backend_testing.yaml
@@ -1,6 +1,10 @@
 name: Testing Flow
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   testing:


### PR DESCRIPTION
Only trigger CI workflows when we merge into main, or push into main directly. Don't do it when we push to a feature branch. 