### PR TITLE
Add debounce to week and date filters' change

### DIFF
--- a/ui-react/src/components/DatesFilter.tsx
+++ b/ui-react/src/components/DatesFilter.tsx
@@ -1,36 +1,68 @@
-import type { ChangeEvent } from "react";
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import type { DatesFilterProps } from "@/types/props";
+
+const DEBOUNCE_MS = 450;
 
 function isValidISODate(date: string) {
   return !Number.isNaN(Date.parse(date));
 }
 
+type DraftDates = { dateFrom: string; dateTo: string };
+
 export default function DatesFilter(props: DatesFilterProps) {
-  function handleDateFilterChange(event: ChangeEvent<HTMLInputElement>) {
-    let { dateFrom, dateTo } = props.selectedValues ?? {};
+  const [draft, setDraft] = useState<DraftDates>(() => ({
+    dateFrom: props.selectedValues?.dateFrom ?? "",
+    dateTo: props.selectedValues?.dateTo ?? "",
+  }));
 
-    if (event.target.name === "date_from") {
-      dateFrom = event.target.value;
-      if (dateFrom !== "" && !isValidISODate(dateFrom)) {
-        props.showToast("error", "Invalid 'date from' value");
-        return;
-      }
-    } else if (event.target.name === "date_to") {
-      dateTo = event.target.value;
-      if (dateTo != "" && !isValidISODate(dateTo)) {
-        props.showToast("error", "Invalid 'date to' value");
-        return;
-      }
-      if (dateTo != "" && dateFrom && dateFrom != "" && dateTo < dateFrom) {
-        props.showToast("error", "'Date To' must be after 'Date From'");
-        return;
-      }
-    }
+  const handleValueChangeRef = useRef(props.handleValueChange);
+  const showToastRef = useRef(props.showToast);
+  handleValueChangeRef.current = props.handleValueChange;
+  showToastRef.current = props.showToast;
 
-    props.handleValueChange({
-      dateFrom: dateFrom ?? "",
-      dateTo: dateTo ?? "",
+  useEffect(() => {
+    setDraft({
+      dateFrom: props.selectedValues?.dateFrom ?? "",
+      dateTo: props.selectedValues?.dateTo ?? "",
     });
+  }, [props.selectedValues?.dateFrom, props.selectedValues?.dateTo]);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      const { dateFrom, dateTo } = draft;
+
+      if (dateFrom !== "" && !isValidISODate(dateFrom)) {
+        showToastRef.current("error", "Invalid 'date from' value");
+        return;
+      }
+      if (dateTo !== "" && !isValidISODate(dateTo)) {
+        showToastRef.current("error", "Invalid 'date to' value");
+        return;
+      }
+      if (
+        dateTo !== "" &&
+        dateFrom !== "" &&
+        dateTo < dateFrom
+      ) {
+        showToastRef.current("error", "'Date To' must be after 'Date From'");
+        return;
+      }
+
+      handleValueChangeRef.current({
+        dateFrom,
+        dateTo,
+      });
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(id);
+  }, [draft]);
+
+  function handleDateFilterChange(event: ChangeEvent<HTMLInputElement>) {
+    const { name, value } = event.target;
+    if (name === "date_from") {
+      setDraft((prev) => ({ ...prev, dateFrom: value }));
+    } else if (name === "date_to") {
+      setDraft((prev) => ({ ...prev, dateTo: value }));
+    }
   }
 
   return (
@@ -40,7 +72,7 @@ export default function DatesFilter(props: DatesFilterProps) {
       </label>
       <input
         name="date_from"
-        value={props.selectedValues?.dateFrom ?? ""}
+        value={draft.dateFrom}
         type="date"
         id="date_from"
         className="dates-filter__input"
@@ -51,7 +83,7 @@ export default function DatesFilter(props: DatesFilterProps) {
       </label>
       <input
         name="date_to"
-        value={props.selectedValues?.dateTo ?? ""}
+        value={draft.dateTo}
         type="date"
         id="date_to"
         className="dates-filter__input"

--- a/ui-react/src/components/WeeksFilter.tsx
+++ b/ui-react/src/components/WeeksFilter.tsx
@@ -1,19 +1,46 @@
-import type { ChangeEvent } from "react";
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import type { WeeksFilterProps } from "@/types/props";
 
+const DEBOUNCE_MS = 350;
+
 export default function WeeksFilter(props: WeeksFilterProps) {
-  function handleWeeksLimitChange(event: ChangeEvent<HTMLInputElement>) {
-    const valueEntered = event.target.value;
-    if (valueEntered === "") {
-      props.handleValueChange({});
-    } else {
-      const numericValue = Number(valueEntered);
-      if (numericValue < 1 || Number.isNaN(numericValue)) {
-        props.showToast("error", "Weeks selection must be 1 or above");
-        return ;
+  const [draft, setDraft] = useState(() =>
+    props.selectedValues?.weeksLimit != null
+      ? String(props.selectedValues.weeksLimit)
+      : ""
+  );
+
+  const handleValueChangeRef = useRef(props.handleValueChange);
+  const showToastRef = useRef(props.showToast);
+  handleValueChangeRef.current = props.handleValueChange;
+  showToastRef.current = props.showToast;
+
+  useEffect(() => {
+    const fromProps =
+      props.selectedValues?.weeksLimit != null
+        ? String(props.selectedValues.weeksLimit)
+        : "";
+    setDraft(fromProps);
+  }, [props.selectedValues?.weeksLimit]);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      if (draft === "") {
+        handleValueChangeRef.current({});
+        return;
       }
-      props.handleValueChange({weeksLimit: numericValue})
-    }
+      const numericValue = Number(draft);
+      if (numericValue < 1 || Number.isNaN(numericValue)) {
+        showToastRef.current("error", "Weeks selection must be 1 or above");
+        return;
+      }
+      handleValueChangeRef.current({ weeksLimit: numericValue });
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(id);
+  }, [draft]);
+
+  function handleWeeksLimitChange(event: ChangeEvent<HTMLInputElement>) {
+    setDraft(event.target.value);
   }
 
   return (
@@ -34,7 +61,7 @@ export default function WeeksFilter(props: WeeksFilterProps) {
       <input
         name="weeks_limit"
         type="number"
-        value={props.selectedValues?.weeksLimit ?? ""}
+        value={draft}
         id="weeks_limit"
         className="weeks-filter__input"
         onChange={handleWeeksLimitChange}


### PR DESCRIPTION
Add debounce logic to the queries sent when WeeksFilter and DatesFilter value changes. Avoid sending too many useless queries to backend. 